### PR TITLE
fix(auth): explicit admin allowlist instead of username-suffix convention

### DIFF
--- a/mcprelay/auth.py
+++ b/mcprelay/auth.py
@@ -39,20 +39,31 @@ class AuthManager:
 
     def _build_api_key_cache(self):
         """Build API key lookup cache."""
+        self._admin_users = set(self.config.auth.admin_users)
         for api_key, user_id in self.config.auth.api_keys.items():
             # Hash API key for security
             key_hash = hashlib.sha256(api_key.encode()).hexdigest()
             self.api_key_cache[key_hash] = {
                 "user_id": user_id,
-                "is_admin": user_id.endswith("-admin"),
+                "is_admin": self._is_admin_user(user_id),
                 "rate_limit_tier": self._get_user_rate_tier(user_id),
             }
+
+    def _is_admin_user(self, user_id: str) -> bool:
+        """Decide whether a user_id has admin privileges.
+
+        The explicit ``auth.admin_users`` allowlist is the source of truth. The
+        legacy ``-admin`` username-suffix convention is still honoured for
+        backward compatibility, but it is fragile (``"not-admin"`` matches it),
+        so the allowlist should be preferred for new configurations.
+        """
+        return user_id in self._admin_users or user_id.endswith("-admin")
 
     def _get_user_rate_tier(self, user_id: str) -> str:
         """Get rate limit tier for user."""
         if user_id in self.config.rate_limit.per_user_limits:
             return "custom"
-        elif user_id.endswith("-admin"):
+        elif self._is_admin_user(user_id):
             return "admin"
         return "default"
 

--- a/mcprelay/config.py
+++ b/mcprelay/config.py
@@ -29,6 +29,16 @@ class AuthConfig(BaseModel):
     api_keys: Dict[str, str] = Field(
         default_factory=dict, description="API key to user mapping"
     )
+    admin_users: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Explicit allowlist of user IDs granted admin privileges. This is "
+            "the source of truth for admin access on the API-key auth path. The "
+            "legacy '-admin' username-suffix convention is still honoured for "
+            "backward compatibility but is fragile (e.g. a user named "
+            "'not-admin' matches it) and should not be relied on for new setups."
+        ),
+    )
 
 
 class RateLimitConfig(BaseModel):

--- a/tests/test_auth_admin.py
+++ b/tests/test_auth_admin.py
@@ -1,0 +1,81 @@
+"""Tests for admin-privilege determination on the API-key auth path.
+
+Admin access on the API-key path is decided by ``AuthManager._is_admin_user``:
+the explicit ``auth.admin_users`` allowlist is the source of truth, and the
+legacy ``-admin`` username-suffix convention is honoured only for backward
+compatibility.
+"""
+
+import pytest
+
+from mcprelay.auth import AuthManager
+from mcprelay.config import MCPRelayConfig
+
+
+def _manager(api_keys=None, admin_users=None, per_user_limits=None) -> AuthManager:
+    config = MCPRelayConfig()
+    config.auth.api_keys = api_keys or {}
+    config.auth.admin_users = admin_users or []
+    config.rate_limit.per_user_limits = per_user_limits or {}
+    return AuthManager(config)
+
+
+class TestIsAdminUser:
+    def test_explicit_allowlist_grants_admin(self):
+        mgr = _manager(admin_users=["alice"])
+        assert mgr._is_admin_user("alice") is True
+
+    def test_user_not_in_allowlist_is_not_admin(self):
+        mgr = _manager(admin_users=["alice"])
+        assert mgr._is_admin_user("bob") is False
+
+    def test_plain_user_is_not_admin(self):
+        assert _manager()._is_admin_user("regular-user") is False
+
+    def test_legacy_suffix_still_grants_admin_for_backcompat(self):
+        # The '-admin' convention must keep working so existing configs don't break.
+        assert _manager()._is_admin_user("ops-admin") is True
+
+    def test_allowlist_grants_admin_without_suffix(self):
+        # The whole point: admin without needing a magic username suffix.
+        mgr = _manager(admin_users=["plain-name"])
+        assert mgr._is_admin_user("plain-name") is True
+
+
+class TestApiKeyCacheAdminFlag:
+    def test_api_key_for_allowlisted_user_is_admin(self):
+        mgr = _manager(api_keys={"sk-1": "alice"}, admin_users=["alice"])
+        ctx = mgr.api_key_cache[_hash("sk-1")]
+        assert ctx["is_admin"] is True
+        assert ctx["rate_limit_tier"] == "admin"
+
+    def test_api_key_for_plain_user_is_not_admin(self):
+        mgr = _manager(api_keys={"sk-2": "bob"})
+        ctx = mgr.api_key_cache[_hash("sk-2")]
+        assert ctx["is_admin"] is False
+        assert ctx["rate_limit_tier"] == "default"
+
+    def test_custom_rate_tier_takes_precedence(self):
+        mgr = _manager(
+            api_keys={"sk-3": "carol"},
+            admin_users=["carol"],
+            per_user_limits={"carol": 5},
+        )
+        ctx = mgr.api_key_cache[_hash("sk-3")]
+        assert ctx["is_admin"] is True
+        assert ctx["rate_limit_tier"] == "custom"
+
+
+@pytest.mark.asyncio
+async def test_validate_api_key_returns_admin_context():
+    mgr = _manager(api_keys={"sk-admin": "root"}, admin_users=["root"])
+    ctx = await mgr.validate_api_key("sk-admin")
+    assert ctx is not None
+    assert ctx.user_id == "root"
+    assert ctx.is_admin is True
+
+
+def _hash(api_key: str) -> str:
+    import hashlib
+
+    return hashlib.sha256(api_key.encode()).hexdigest()


### PR DESCRIPTION
## Problem

Admin privileges on the **API-key auth path** were decided purely by a username convention:

```python
"is_admin": user_id.endswith("-admin")   # auth.py
```

Two problems:
1. **Footgun:** `"not-admin".endswith("-admin")` is `True` — a user an operator names to read as *non*-admin silently gets admin.
2. **Inconsistency:** the JWT path already uses an explicit `payload.get("admin", False)` claim. Only the API-key path relied on the magic suffix.

Convention-based authorization is a weak primitive for a security gateway.

## Fix

- Add `auth.admin_users` — an explicit allowlist of user IDs, now the **source of truth** for admin on the API-key path.
- Keep the `-admin` suffix working (**backward compatible**) but document it as fragile/legacy.
- Centralise the decision in `AuthManager._is_admin_user` so the rate-tier lookup (`admin` tier) uses the same rule instead of a second copy of the suffix check.

Purely **additive**: the new field defaults to `[]`, so existing configs behave exactly as before.

## Tests

9 new tests (`tests/test_auth_admin.py`): explicit allowlist grants admin, non-listed user is not admin, legacy suffix still works, allowlist grants admin *without* a magic suffix, and the admin-vs-custom rate-tier precedence. Full suite: **27 passed** (was 18).